### PR TITLE
edit($flushChunks): omit before option, and use cssHash string

### DIFF
--- a/src/server/middleware/reactApplication/generateHTML.js
+++ b/src/server/middleware/reactApplication/generateHTML.js
@@ -52,13 +52,9 @@ export default function generateHTML(args: Args) {
   // arrays of file names (not including publicPath):
   scripts,
   stylesheets,
-  cssHashRaw,
+  cssHash,
   publicPath,
-  } = flushChunks(clientEntryStats, {
-    chunkNames,
-    before: ['bootstrap', 'vendor'],
-    after: ['index'],
-  });
+  } = flushChunks(clientEntryStats, { chunkNames, after: ['index'] });
 
   // Creates an inline script definition that is protected by the nonce.
   const inlineScript = body =>
@@ -90,11 +86,7 @@ export default function generateHTML(args: Args) {
             ? inlineScript(`window.__APP_STATE__=${serialize(initialState)};`)
             : ''
         }
-        ${
-          cssHashRaw
-            ? inlineScript(`window.__CSS_CHUNKS__=${serialize(cssHashRaw)};`)
-            : ''
-        }
+        ${cssHash}
         ${
           // Enable the polyfill io script?
           // This can't be configured within a react-helmet component as we


### PR DESCRIPTION
you're using the defaults for the before option, so you don't need it.

and for `cssHashRaw` serialize-javascript doesn't get you anything since you don't have regexes and the like in the cssHash. Maybe u wanna keep that so it looks like the above lines and therefore so it's more explicit and better indicates to other developers what it does.

...if u dont want these all good, i know explicitness is useful. just figured i'd let u know in case u didn't.